### PR TITLE
README.rst: Fix title underline too short

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-===============================
+================================
 Transactional Celery for Pyramid
-===============================
+================================
 
 .. image:: https://badge.fury.io/py/pyramid_transactional_celery.png
     :target: http://badge.fury.io/py/pyramid_transactional_celery


### PR DESCRIPTION
This may or may not be the only thing causing issue #1. It's pretty annoying to find these problems, as detailed in https://bitbucket.org/pypa/pypi/issue/161/rest-formatting-fails-and-there-is-no-way
