### PR TITLE
Fix Task class to support retries.

### DIFF
--- a/pyramid_transactional_celery/transactional_task.py
+++ b/pyramid_transactional_celery/transactional_task.py
@@ -72,8 +72,9 @@ class CeleryDataManager(object):
 
     def tpc_finish(self, transaction):
         while self.queued_tasks:
-            cls, args, kwargs = self.queued_tasks.pop(0)
-            cls.original_apply_async(*args, **kwargs)
+            task_instance, args, kwargs = self.queued_tasks.pop(0)
+            task_instance.apply_async(*args, bypass_transaction_manager=True, **kwargs)
+
         self.in_commit = False
         self._cleanup()
 
@@ -85,16 +86,17 @@ class CeleryDataManager(object):
 
 
 class TransactionalTask(Task):
-    """A task whose execution is delayed until after the current transaction.
-    """
-    abstract = True
+    """A task whose execution is delayed until the current transaction gets committed."""
 
-    def original_apply_async(self, *args, **kwargs):
-        """Shortcut method to reach real implementation of
-        celery.Task.apply_sync"""
-        return super(TransactionalTask, self).apply_async(*args, **kwargs)
+    def retry(self, *args, **kwargs):
+        return super(TransactionalTask, self).retry(*args, bypass_transaction_manager=True, **kwargs)
 
     def apply_async(self, *args, **kwargs):
-        _get_manager().append((self, args, kwargs))
+        bypass_transaction_manager = kwargs.pop('bypass_transaction_manager', None)
+
+        if bypass_transaction_manager:
+            return super(TransactionalTask, self).apply_async(*args, **kwargs)
+        else:
+            _get_manager().append((self, args, kwargs))
 
 task_tm = partial(base_task, base=TransactionalTask)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 wheel==0.23.0
 transaction
-celery >= 3.1
+celery >= 3.1, < 4


### PR DESCRIPTION
It was found that `apply_async` method had a problem, by making no distinction between the original call, and the `retry` calls. Like that, at transaction's commit phase - when the task was eventually called - it hooked the `retry` on the current transaction, but with no effect once at this commit phase.